### PR TITLE
chore: Update npm dependency to latest stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install modulatecss
 Or include it directly via CDN:
 
 ```html
-<link href="https://cdn.jsdelivr.net/npm/modulate@1.0.0/dist/css/modulate.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/modulate@latest/dist/css/modulate.min.css" rel="stylesheet">
 ```
 
 ## Integration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modulatecss",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "...",
   "main": "dist/css/modulate.min.css",
   "style": "dist/css/modulate.min.css",


### PR DESCRIPTION
This pull request includes updates to the `modulatecss` package. The changes involve updating the version of the package and modifying the CDN link in the `README.md` file to point to the latest version of the package.

Key changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24): Updated the CDN link to point to the latest version of `modulatecss` instead of a specific version.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version of `modulatecss` from `1.0.40` to `1.0.41`.